### PR TITLE
Allow multiple hooks of type styleManagerFindByTable

### DIFF
--- a/src/Resources/contao/models/StyleManagerModel.php
+++ b/src/Resources/contao/models/StyleManagerModel.php
@@ -131,7 +131,10 @@ class StyleManagerModel extends \Model
                 {
                     foreach ($GLOBALS['TL_HOOKS']['styleManagerFindByTable'] as $callback)
                     {
-                        return \System::importStatic($callback[0])->{$callback[1]}($strTable, $arrOptions);
+                        if (null !== ($result = \Contao\System::importStatic($callback[0])->{$callback[1]}($strTable, $arrOptions)))
+                        {
+                            return $result;
+                        }
                     }
                 }
 


### PR DESCRIPTION
At the moment it is only possible to register one hook of type `styleManagerFindByTable`, because after executing the hook the loop is aborted!