### PR TITLE
Invalid SQL definition for cssID

### DIFF
--- a/src/Resources/contao/dca/tl_article.php
+++ b/src/Resources/contao/dca/tl_article.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_article']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_article']['fields']['cssID']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_article']['fields']['cssID']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_article']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_article']['fields']['cssID']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -19,7 +19,7 @@ if (isset($bundles['ContaoCalendarBundle']))
         'sql'                     => "blob NULL"
     );
 
-    $GLOBALS['TL_DCA']['tl_calendar_events']['fields']['cssClass']['sql'] = "text NOT NULL default ''";
+    $GLOBALS['TL_DCA']['tl_calendar_events']['fields']['cssClass']['sql'] = "text NULL";
 
     $GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
     $GLOBALS['TL_DCA']['tl_calendar_events']['fields']['cssClass']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_content']['fields']['cssID']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_content']['fields']['cssID']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_content']['fields']['cssID']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_form.php
+++ b/src/Resources/contao/dca/tl_form.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_form']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_form']['fields']['attributes']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_form']['fields']['attributes']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_form']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_form']['fields']['attributes']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_form_field']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_form_field']['fields']['class']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_form_field']['fields']['class']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_form_field']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_form_field']['list']['sorting']['child_record_callback'] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'listFormFields');

--- a/src/Resources/contao/dca/tl_layout.php
+++ b/src/Resources/contao/dca/tl_layout.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_layout']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_layout']['fields']['cssClass']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_layout']['fields']['cssClass']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_layout']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_layout']['fields']['cssClass']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_module']['fields']['cssID']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_module']['fields']['cssID']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_module']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_module']['fields']['cssID']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -19,7 +19,7 @@ if (isset($bundles['ContaoNewsBundle']))
         'sql'                     => "blob NULL"
     );
 
-    $GLOBALS['TL_DCA']['tl_news']['fields']['cssClass']['sql'] = "text NOT NULL default ''";
+    $GLOBALS['TL_DCA']['tl_news']['fields']['cssClass']['sql'] = "text NULL";
 
     $GLOBALS['TL_DCA']['tl_news']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
     $GLOBALS['TL_DCA']['tl_news']['fields']['cssClass']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['styleManager'] = array
     'sql'                     => "blob NULL"
 );
 
-$GLOBALS['TL_DCA']['tl_page']['fields']['cssClass']['sql'] = "text NOT NULL default ''";
+$GLOBALS['TL_DCA']['tl_page']['fields']['cssClass']['sql'] = "text NULL";
 
 $GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'addPalette');
 $GLOBALS['TL_DCA']['tl_page']['fields']['cssClass']['load_callback'][] = array('\\Oveleon\\ContaoComponentStyleManager\\StyleManager', 'onLoad');


### PR DESCRIPTION
a `TEXT` field cannot have a default value in MySQL. This fails in strict mode, because the field is not allowed to be `NULL`. Using `text NULL` is the default approach in Contao.