### PR TITLE
Add a way to handle dynamic options

### DIFF
--- a/src/Resources/contao/widgets/ComponentStyleSelect.php
+++ b/src/Resources/contao/widgets/ComponentStyleSelect.php
@@ -144,9 +144,9 @@ class ComponentStyleSelect extends Widget
                 );
 
                 // skip third-party fields
-                if (isset($GLOBALS['TL_HOOKS']['styleManagerGetDynamicFieldOptions']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerGetDynamicFieldOptions']))
+                if (isset($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions']))
                 {
-                    foreach ($GLOBALS['TL_HOOKS']['styleManagerGetDynamicFieldOptions'] as $callback)
+                    foreach ($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions'] as $callback)
                     {
                         if($optionCallback = System::importStatic($callback[0])->{$callback[1]}($option, $objStyleGroups->current(), $this))
                         {

--- a/src/Resources/contao/widgets/ComponentStyleSelect.php
+++ b/src/Resources/contao/widgets/ComponentStyleSelect.php
@@ -138,10 +138,24 @@ class ComponentStyleSelect extends Widget
             $opts = StringUtil::deserialize($objStyleGroups->cssClasses);
 
             foreach ($opts as $opt) {
-                $arrFieldOptions[] = array(
+                $option = array(
                     'label' => $opt['value'] ?: $opt['key'],
                     'value' => $opt['key']
                 );
+
+                // skip third-party fields
+                if (isset($GLOBALS['TL_HOOKS']['styleManagerGetDynamicFieldOptions']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerGetDynamicFieldOptions']))
+                {
+                    foreach ($GLOBALS['TL_HOOKS']['styleManagerGetDynamicFieldOptions'] as $callback)
+                    {
+                        if($optionCallback = System::importStatic($callback[0])->{$callback[1]}($option, $objStyleGroups->current(), $this))
+                        {
+                            $option = $optionCallback;
+                        }
+                    }
+                }
+
+                $arrFieldOptions[] = $option;
             }
 
             // set options

--- a/src/Resources/contao/widgets/ComponentStyleSelect.php
+++ b/src/Resources/contao/widgets/ComponentStyleSelect.php
@@ -123,7 +123,7 @@ class ComponentStyleSelect extends Widget
                 }
             }
 
-            // skip third-party fields
+            // dynamically change or expand group options
             if (isset($GLOBALS['TL_HOOKS']['styleManagerSkipField']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerSkipField']))
             {
                 foreach ($GLOBALS['TL_HOOKS']['styleManagerSkipField'] as $callback)

--- a/src/Resources/contao/widgets/ComponentStyleSelect.php
+++ b/src/Resources/contao/widgets/ComponentStyleSelect.php
@@ -123,7 +123,7 @@ class ComponentStyleSelect extends Widget
                 }
             }
 
-            // dynamically change or expand group options
+            // skip third-party fields
             if (isset($GLOBALS['TL_HOOKS']['styleManagerSkipField']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerSkipField']))
             {
                 foreach ($GLOBALS['TL_HOOKS']['styleManagerSkipField'] as $callback)
@@ -143,19 +143,19 @@ class ComponentStyleSelect extends Widget
                     'value' => $opt['key']
                 );
 
-                // skip third-party fields
-                if (isset($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions']))
+                $arrFieldOptions[] = $option;
+            }
+
+            // dynamically change or expand group options
+            if (isset($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions']) && \is_array($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions']))
+            {
+                foreach ($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions'] as $callback)
                 {
-                    foreach ($GLOBALS['TL_HOOKS']['styleManagerGroupFieldOptions'] as $callback)
+                    if($optionCallback = System::importStatic($callback[0])->{$callback[1]}($arrFieldOptions, $objStyleGroups->current(), $this))
                     {
-                        if($optionCallback = System::importStatic($callback[0])->{$callback[1]}($option, $objStyleGroups->current(), $this))
-                        {
-                            $option = $optionCallback;
-                        }
+                        $arrFieldOptions = $optionCallback;
                     }
                 }
-
-                $arrFieldOptions[] = $option;
             }
 
             // set options


### PR DESCRIPTION
Hi!
Second and last PR from me ;)

For a project, I worked with a framework and a lot of classes could be useful. But since it could evolve, it would be too heavy to update the CSS and the Style Manager. So I made a hook who can be triggered when the options of the widget are loaded.
In the function, I could open the CSS, parse the classes and return them correctly formatted.
I used a keyword to know I'm in the right widget too.

Let me know if it's something you might add in your repo :)
Thanks again!