### PR TITLE
Do not return label as array

### DIFF
--- a/src/Resources/contao/dca/tl_style_manager_archive.php
+++ b/src/Resources/contao/dca/tl_style_manager_archive.php
@@ -208,19 +208,17 @@ class tl_style_manager_archive extends \Backend
      *
      * @param array         $row
      * @param string        $label
-     * @param DataContainer $dc
-     * @param array         $args
      *
-     * @return array
+     * @return string
      */
-    public function addIdentifierInfo($row, $label, DataContainer $dc, $args)
+    public function addIdentifierInfo($row, $label)
     {
         if($row['identifier'])
         {
-            $args[0] .= '<span style="color:#999;padding-left:3px">[' . $row['identifier'] . ']</span>';
+            $label .= '<span style="color:#999;padding-left:3px">[' . $row['identifier'] . ']</span>';
         }
 
-        return $args;
+        return $label;
     }
 
     /**


### PR DESCRIPTION
Since `showColumns` is not active for this DCA, there is no need to return the label as an array. See also https://github.com/contao/contao/issues/4125 / https://github.com/contao/contao/pull/4126