### PR TITLE
Fix undefined array key warning

### DIFF
--- a/src/Resources/contao/dca/tl_style_manager.php
+++ b/src/Resources/contao/dca/tl_style_manager.php
@@ -71,7 +71,7 @@ $GLOBALS['TL_DCA']['tl_style_manager'] = array
                 'label'               => &$GLOBALS['TL_LANG']['tl_style_manager']['delete'],
                 'href'                => 'act=delete',
                 'icon'                => 'delete.svg',
-                'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+                'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
             ),
             'show' => array
             (

--- a/src/Resources/contao/dca/tl_style_manager_archive.php
+++ b/src/Resources/contao/dca/tl_style_manager_archive.php
@@ -91,7 +91,7 @@ $GLOBALS['TL_DCA']['tl_style_manager_archive'] = array
                 'label'               => &$GLOBALS['TL_LANG']['tl_style_manager_archive']['delete'],
                 'href'                => 'act=delete',
                 'icon'                => 'delete.svg',
-                'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+                'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
             ),
             'show' => array
             (


### PR DESCRIPTION
Fixes

```
In tl_style_manager_archive.php line 97:

  Warning: Undefined array key "deleteConfirm" 
```

under PHP 8+ in the same way that the Contao core does.