### PR TITLE
[Bugfix] Remove strict check for $href in config buttons

### DIFF
--- a/src/EventListener/DataContainer/StyleManagerArchiveListener.php
+++ b/src/EventListener/DataContainer/StyleManagerArchiveListener.php
@@ -43,7 +43,7 @@ class StyleManagerArchiveListener
     /**
      * @Callback(table="tl_style_manager_archive", target="list.global_operations.import.button")
      */
-    public function importConfigButton(string $href, string $label, string $title, string $class, string $attributes): string
+    public function importConfigButton(?string $href, string $label, string $title, string $class, string $attributes): string
     {
         if(System::getContainer()->getParameter('contao_component_style_manager.use_bundle_config'))
         {
@@ -65,7 +65,7 @@ class StyleManagerArchiveListener
     /**
      * @Callback(table="tl_style_manager_archive", target="list.global_operations.config.button")
      */
-    public function bundleConfigButton(string $href, string $label, string $title, string $class, string $attributes): string
+    public function bundleConfigButton(?string $href, string $label, string $title, string $class, string $attributes): string
     {
         if(System::getContainer()->getParameter('contao_component_style_manager.use_bundle_config'))
         {


### PR DESCRIPTION
When opening the config within PHP 8.1 and 8.2, it throws an error as the argument $href is not parsed

Can be reproduced by not having any archives and having bundle configurations

![image](https://user-images.githubusercontent.com/55794780/221425060-978e14ca-73d4-40c6-a317-d0f51fd6a6b0.png)

