### PR TITLE
Use FQCN for DC driver

### DIFF
--- a/src/Resources/contao/dca/tl_style_manager.php
+++ b/src/Resources/contao/dca/tl_style_manager.php
@@ -5,11 +5,13 @@
  * (c) https://www.oveleon.de/
 */
 
+use Contao\DC_Table;
+
 $GLOBALS['TL_DCA']['tl_style_manager'] = [
 
     // Config
     'config' => [
-        'dataContainer'    => 'Table',
+        'dataContainer'    => DC_Table::class,
         'ptable'           => 'tl_style_manager_archive',
         'switchToEdit'     => true,
         'enableVersioning' => true,

--- a/src/Resources/contao/dca/tl_style_manager_archive.php
+++ b/src/Resources/contao/dca/tl_style_manager_archive.php
@@ -5,10 +5,12 @@
  * (c) https://www.oveleon.de/
 */
 
+use Contao\DC_Table;
+
 $GLOBALS['TL_DCA']['tl_style_manager_archive'] = [
     // Config
     'config' => [
-        'dataContainer'               => 'Table',
+        'dataContainer'               => DC_Table::class,
         'ctable'                      => ['tl_style_manager'],
         'switchToEdit'                => true,
         'enableVersioning'            => true,


### PR DESCRIPTION
Fixes the following error in Contao 5:

```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError:
Attempted to load class "Table" from the global namespace.
Did you forget a "use" statement for e.g. "Symfony\Component\Console\Helper\Table", "Spatie\SchemaOrg\Table", "League\CommonMark\Extension\Table\Table", "Doctrine\ORM\Mapping\Table" or "Doctrine\DBAL\Schema\Table"?
```