### PR TITLE
Fixed wrong class override with bundle config

### DIFF
--- a/src/StyleManager/Sync.php
+++ b/src/StyleManager/Sync.php
@@ -205,12 +205,13 @@ class Sync
                                 }
 
                                 // Overwrite existing value
-                                $key = array_search($field, array_column($arrClasses, 'key'));
-
-                                $arrClasses[ $key ] = [
-                                    'key' => $cssClass['key'],
-                                    'value' => $cssClass['value']
-                                ];
+                                if (!$key = array_search($field, array_column($arrClasses, 'key')))
+                                {
+                                    $arrClasses[ $key ] = [
+                                        'key' => $cssClass['key'],
+                                        'value' => $cssClass['value']
+                                    ];
+                                }
 
                                 continue;
                             }


### PR DESCRIPTION
- if an option was not found, the first value has been overwritten due to array_search returning false, hence searching for the first key '0' within the classes array