### PR TITLE
Skip migrations for non-existing style-manager groups (#84)

### DIFF
--- a/src/StyleManager/Sync.php
+++ b/src/StyleManager/Sync.php
@@ -73,7 +73,7 @@ class Sync
             if (is_numeric($key) && empty(StyleManagerModel::findById($key)))
             {
                 // Skip if the configuration was already converted or can not be found anymore as the PK does not exist
-                $this->logger->error('Style Manager conversion for table "'.$table.'" and id "'.$key.'" has been skipped due to primary key not existing anymore.)');
+                $this->logger->error('Style Manager conversion for table "'.$table.'" and id "'.$key.'" has been skipped due to primary key not existing anymore.');
                 return false;
             }
 


### PR DESCRIPTION
<h3>Bugfix</h3>

- Don't show version 2->3 migrations for style-manager groups that do not exist anymore https://github.com/oveleon/contao-component-style-manager/commit/88228d58fba92567e0e32aa6712aa177917a57f2