### PR TITLE
Reset excluded groups when calling prepare method

### DIFF
--- a/src/StyleManager/Styles.php
+++ b/src/StyleManager/Styles.php
@@ -86,6 +86,7 @@ class Styles
     {
         $this->currIdentifier = $identifier;
         $this->currGroups     = $arrGroups;
+        $this->exclGroups     = null;
 
         return $this;
     }


### PR DESCRIPTION
The current behavior of the `exclude()` method drops options out of the class collection. This resets the excluded classlist on `prepare()`