### PR TITLE
Correctly override bundle-configuration

### DIFF
--- a/src/StyleManager/Sync.php
+++ b/src/StyleManager/Sync.php
@@ -217,7 +217,7 @@ class Sync
                                 }
 
                                 // Overwrite existing value
-                                if (!$key = array_search($field, array_column($arrClasses, 'key')))
+                                if (false !== ($key = array_search($cssClass['key'], array_column($arrClasses, 'key'))))
                                 {
                                     $arrClasses[ $key ] = [
                                         'key' => $cssClass['key'],


### PR DESCRIPTION
### Description

* This PR fixes an issue where trying to override the bundle-configuration via style-manager archives would result in only replacing the first value.

* Also fixes #99 

### Explanation of the bug

```php
// Overwrite existing value
if (!$key = array_search($field, array_column($arrClasses, 'key')))
{
    $arrClasses[ $key ] = [
        'key' => $cssClass['key'],
        'value' => $cssClass['value']
    ];
}
```

* `$field` has always been `$field = 'cssClasses'` and not the class key
* The return value of array_search has always been false since `cssClasses` was never within the classlist, thus returning `false`
* Checking for `!false` would return `true` which would trigger the condition
* The `$key` would be false, `$arrClasses[false]` is the same as `$arrClasses[0]` and would replace the index with number 0

![image](https://github.com/oveleon/contao-component-style-manager/assets/55794780/13974fbe-cf33-4083-908f-55028bd13763)

![image](https://github.com/oveleon/contao-component-style-manager/assets/55794780/25a51657-fbd8-4921-b083-d7410df6b1f3)

### The fix

This is fixed with the following code since it'll actually get they `$key` based on the $cssClass['key'] now.
I also changed it to check for false !== $key rather than !$key for type safety
```php
// Overwrite existing value
if (false !== ($key = array_search($cssClass['key'], array_column($arrClasses, 'key'))))
{
    ...
```

![image](https://github.com/oveleon/contao-component-style-manager/assets/55794780/5278c3fb-319c-4d95-a8fb-0d487a0419b3)
