### PR TITLE
Skip migration if field does not exist

### DIFF
--- a/src/StyleManager/Sync.php
+++ b/src/StyleManager/Sync.php
@@ -59,7 +59,7 @@ class Sync
             return false;
         }
 
-        $columnNames = array_map(static function (Column $column) {
+        $columnNames = array_map(static function (Column $column): string {
             return $column->getName();
         }, $schemaManager->listTableColumns($table));
 

--- a/src/StyleManager/Sync.php
+++ b/src/StyleManager/Sync.php
@@ -18,6 +18,7 @@ use Contao\StringUtil;
 use Contao\System;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Column;
 use DOMDocument;
 use DOMElement;
 use DOMNode;
@@ -55,6 +56,14 @@ class Sync
 
         if(null === $table || !$schemaManager->tablesExist([$table]))
         {
+            return false;
+        }
+
+        $columnNames = array_map(static function (Column $column) {
+            return $column->getName();
+        }, $schemaManager->listTableColumns($table));
+
+        if (!\in_array('styleManager', $columnNames, true)) {
             return false;
         }
 


### PR DESCRIPTION
During migration from 2.x to 3.x the following error occurs:

```
 [PDOException (42S22)]
  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'styleManager' in 'field list'  


Exception trace:
  at vendor\doctrine\dbal\src\Driver\PDO\Connection.php:71
 PDO->query() at vendor\doctrine\dbal\src\Driver\PDO\Connection.php:71
 Doctrine\DBAL\Driver\PDO\Connection->query() at vendor\doctrine\dbal\src\Driver\Middleware\AbstractConnectionMiddleware.php:33
 Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware->query() at vendor\doctrine\dbal\src\Logging\Connection.php:43
 Doctrine\DBAL\Logging\Connection->query() at vendor\doctrine\dbal\src\Driver\Middleware\AbstractConnectionMiddleware.php:33
 Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware->query() at vendor\symfony\doctrine-bridge\Middleware\Debug\DBAL3\Connection.php:69
 Symfony\Bridge\Doctrine\Middleware\Debug\DBAL3\Connection->query() at vendor\doctrine\dbal\src\Connection.php:1101 
 Doctrine\DBAL\Connection->executeQuery() at vendor\doctrine\dbal\src\Connection.php:953
 Doctrine\DBAL\Connection->fetchFirstColumn() at vendor\oveleon\contao-component-style-manager\src\StyleManager\Sync.php:61
 Oveleon\ContaoComponentStyleManager\StyleManager\Sync->shouldRunObjectConversion() at vendor\oveleon\contao-component-style-manager\src\Migration\Version30\ObjectConversionMigration.php:40
 Oveleon\ContaoComponentStyleManager\Migration\Version30\ObjectConversionMigration->shouldRun() at vendor\contao\core-bundle\src\Migration\MigrationCollection.php:47
 Contao\CoreBundle\Migration\MigrationCollection->getPending() at vendor\contao\core-bundle\src\Migration\MigrationCollection.php:58
 Contao\CoreBundle\Migration\MigrationCollection->getPendingNames() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:259
 Contao\CoreBundle\Command\MigrateCommand->executeMigrations() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:208
 Contao\CoreBundle\Command\MigrateCommand->executeCommand() at vendor\contao\core-bundle\src\Command\MigrateCommand.php:109
 Contao\CoreBundle\Command\MigrateCommand->execute() at vendor\symfony\console\Command\Command.php:298
 Symfony\Component\Console\Command\Command->run() at vendor\symfony\console\Application.php:1058
 Symfony\Component\Console\Application->doRunCommand() at vendor\symfony\framework-bundle\Console\Application.php:96 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at vendor\symfony\console\Application.php:301   
 Symfony\Component\Console\Application->doRun() at vendor\symfony\framework-bundle\Console\Application.php:82       
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at vendor\symfony\console\Application.php:171
 Symfony\Component\Console\Application->run() at vendor\contao\manager-bundle\bin\contao-console:38
 include() at vendor\bin\contao-console:119
```

This PR fixes that by skipping the migration if the `styleManager` field does not exist.