### PR TITLE
Do not use `$dc->id` for slug generator

### DIFF
--- a/src/EventListener/DataContainer/StyleManagerListener.php
+++ b/src/EventListener/DataContainer/StyleManagerListener.php
@@ -85,7 +85,7 @@ class StyleManagerListener
         // Generate an alias if there is none
         if ($varValue == '')
         {
-            $varValue = System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, $dc->id, $aliasExists);
+            $varValue = System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, [], $aliasExists);
         }
         elseif ($aliasExists($varValue))
         {


### PR DESCRIPTION
Fixes #106

Using `$dc->id` there is wrong - as the second argument is supposed to be either the slug config array - or a `tl_page` ID.