### PR TITLE
Add cut operation

### DIFF
--- a/contao/dca/tl_style_manager.php
+++ b/contao/dca/tl_style_manager.php
@@ -50,6 +50,10 @@ $GLOBALS['TL_DCA']['tl_style_manager'] = [
                 'href'          => 'act=paste&mode=copy',
                 'icon'          => 'copy.svg'
             ],
+            'cut' => [
+                'href'          => 'act=paste&amp;mode=cut',
+                'icon'          => 'cut.svg'
+            ],
             'delete' => [
                 'href'          => 'act=delete',
                 'icon'          => 'delete.svg',


### PR DESCRIPTION
Currently the `cut` operation is missing in `tl_style_manager`. This PR adds it - or was there a specific reason not to include it by default? As far as I tested everything works - i.e. I can move styles from one archive to another without any issues.