### PR TITLE
Forwards compatibility with Contao 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,11 +75,5 @@
       "php-http/discovery": true,
       "contao/manager-plugin": true
     }
-  },
-  "scripts": {
-    "all": [
-      "@phpstan"
-    ],
-    "phpstan": "@php vendor/bin/phpstan analyze"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": "^8.1",
     "ext-json": "*",
     "ext-dom": "*",
-    "contao/core-bundle": "^4.13 || ^5.1",
+    "contao/core-bundle": "^4.13 || ^5.3",
     "doctrine/dbal": "^3.3",
     "psr/log": "^1.0 || 2.0 || ^3.0",
     "symfony/config": "^5.4 || ^6.4 || ^7.0",
@@ -75,5 +75,11 @@
       "php-http/discovery": true,
       "contao/manager-plugin": true
     }
+  },
+  "scripts": {
+    "all": [
+      "@phpstan"
+    ],
+    "phpstan": "@php vendor/bin/phpstan analyze"
   }
 }

--- a/contao/dca/tl_style_manager.php
+++ b/contao/dca/tl_style_manager.php
@@ -44,7 +44,8 @@ $GLOBALS['TL_DCA']['tl_style_manager'] = [
         'operations' => [
             'edit' => [
                 'href'          => 'act=edit',
-                'icon'          => 'edit.svg'
+                'icon'          => 'edit.svg',
+                'primary'       => true
             ],
             'copy' => [
                 'href'          => 'act=paste&mode=copy',

--- a/contao/dca/tl_style_manager_archive.php
+++ b/contao/dca/tl_style_manager_archive.php
@@ -56,11 +56,13 @@ $GLOBALS['TL_DCA']['tl_style_manager_archive'] = [
         'operations' => [
             'edit' => [
                 'href'                => 'act=edit',
-                'icon'                => 'edit.svg'
+                'icon'                => 'edit.svg',
+                'primary'             => true
             ],
             'children' => [
                 'href'                => 'table=tl_style_manager',
-                'icon'                => 'children.svg'
+                'icon'                => 'children.svg',
+                'primary'             => true
             ],
             'copy' => [
                 'href'                => 'act=copy',

--- a/src/Widget/ComponentStyleSelect.php
+++ b/src/Widget/ComponentStyleSelect.php
@@ -217,6 +217,7 @@ class ComponentStyleSelect extends Widget
             if(!!$objStyleGroup->chosen)
             {
                 $strClass .= ' tl_chosen';
+                $this->arrAttributes['data-controller'] = trim(($this->arrAttributes['data-controller'] ?? '') . ' contao--choices');
             }
 
             // create collection


### PR DESCRIPTION
### Description

This PR provides forwards compatibility for the latest Contao 5.5 version

* `^4.13` and `^5.3` only

Contao 5.5 FC
* set primary operations
* enable `choices` within the stylemanager dropdown fields