### PR TITLE
Remove `switchToEdit`

### DIFF
--- a/contao/dca/tl_style_manager.php
+++ b/contao/dca/tl_style_manager.php
@@ -13,7 +13,6 @@ $GLOBALS['TL_DCA']['tl_style_manager'] = [
     'config' => [
         'dataContainer'    => DC_Table::class,
         'ptable'           => 'tl_style_manager_archive',
-        'switchToEdit'     => true,
         'enableVersioning' => true,
         'markAsCopy'       => 'title',
         'sql' => [


### PR DESCRIPTION
Currently you have a _Save and edit child elements_ form action when editing a style - even though there are no child elements for a style. This is because `switchToEdit` is enabled for this DCA.