### PR TITLE
PoC: Register form callbacks within a compiler pass

### DIFF
--- a/src/ContaoComponentStyleManager.php
+++ b/src/ContaoComponentStyleManager.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 
 namespace Oveleon\ContaoComponentStyleManager;
 
+use Oveleon\ContaoComponentStyleManager\DependencyInjection\StyleManager\StyleManagerContaoCallbackPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ContaoComponentStyleManager extends Bundle
@@ -17,5 +20,12 @@ class ContaoComponentStyleManager extends Bundle
     public function getPath(): string
     {
         return \dirname(__DIR__);
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new StyleManagerContaoCallbackPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 }

--- a/src/DependencyInjection/StyleManager/StyleManagerContaoCallbackPass.php
+++ b/src/DependencyInjection/StyleManager/StyleManagerContaoCallbackPass.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oveleon\ContaoComponentStyleManager\DependencyInjection\StyleManager;
+
+use Composer\InstalledVersions;
+use Oveleon\ContaoComponentStyleManager\StyleManager\StyleManager;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class StyleManagerContaoCallbackPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $class = StyleManager::class;
+
+        if (!$container->hasDefinition($class)) {
+            return;
+        }
+
+        $styleManager = $container->getDefinition($class);
+
+        $styleManager->addTag('contao.callback', [
+            'table'  => 'tl_form_field',
+            'method' => 'listFormFields',
+            'target' => $this->isLegacyContao()
+                ? 'list.sorting.child_record'
+                : 'list.label.label'
+            ,
+        ]);
+    }
+
+    private function isLegacyContao(): bool
+    {
+        $version = InstalledVersions::getVersion('contao/core-bundle');
+        return version_compare($version ?? '0.0.0', '5.7.0', '<');
+    }
+}

--- a/src/StyleManager/StyleManager.php
+++ b/src/StyleManager/StyleManager.php
@@ -414,8 +414,16 @@ class StyleManager
         }
     }
 
-    #[AsCallback(table: 'tl_form_field', target: 'list.sorting.child_record')]
-    public function listFormFields(array $arrRow): string
+    /**
+     * Updates the style manager definition within the form field view.
+     *
+     * Callbacks are registered via the StyleManagerContaoCallbackPass.
+     *
+     * For Contao < 5.7, this method is registered with the 'list.sorting.child_record' callback -> returns string.
+     * For Contao >= 5.7 this method is registered with the 'list.label.label' callback -> returns array.
+     */
+    //#[AsCallback(table: 'tl_form_field', target: 'list.label.label')]
+    public function listFormFields($arrRow): string|array
     {
         $arrStyles = StringUtil::deserialize($arrRow['styleManager']);
         $arrRow['styleManager'] = new Styles($arrStyles[StyleManager::VARS_KEY] ?? null);


### PR DESCRIPTION
### Description

As briefly discussed with @eki89 and as outlined in https://github.com/oveleon/contao-component-style-manager/issues/129#issuecomment-3966176424 as a PoC.

I did not test if this works nor did I test if it works with other extensions. It's a commit I've had pending on my mac for over a month.
<img width="375" height="88" alt="Bildschirmfoto 2026-03-27 um 15 39 26" src="https://github.com/user-attachments/assets/a62c88d3-2b56-4618-abb3-b2c48738888f" />

Listing callbacks are always singular, they may be overwritten by other extensions or it would override those of another extension. The priority of the tag could be changed

Explanation:

Conditional tagging of the service for Contao:
- < 5.7 -> `list.sorting.child_record` (as it used to be)
- ^5.7 -> `list.label.label` -> Using the new callback

The tagging happens in a compiler pass with priortiy 1 and before the optimization (just before contao reads the attribute tags and registers the tagged methods.