### PR TITLE
Remove `child_record_callback` and replace it with a `label_callback`

### DIFF
--- a/src/StyleManager/StyleManager.php
+++ b/src/StyleManager/StyleManager.php
@@ -414,13 +414,13 @@ class StyleManager
         }
     }
 
-    #[AsCallback(table: 'tl_form_field', target: 'list.sorting.child_record')]
-    public function listFormFields(array $arrRow): string
+    #[AsCallback(table: 'tl_form_field', target: 'list.label.label')]
+    public function listFormFields(array $arrRow): array
     {
         $arrStyles = StringUtil::deserialize($arrRow['styleManager']);
         $arrRow['styleManager'] = new Styles($arrStyles[StyleManager::VARS_KEY] ?? null);
 
         $formField = new \tl_form_field();
-        return $formField->listFormFields($arrRow)[1];
+        return $formField->listFormFields($arrRow);
     }
 }


### PR DESCRIPTION
Fixes #132 - see https://github.com/oveleon/contao-component-style-manager/issues/132#issuecomment-4387027445

Since you are already requiring at least Contao 5.7, this can be fixed by switching to the `label_callback`.