### PR TITLE
Avoid undefined array key warning when styleManager data is missing

### DIFF
--- a/src/Twig/StyleManagerExtension.php
+++ b/src/Twig/StyleManagerExtension.php
@@ -48,7 +48,7 @@ class StyleManagerExtension extends AbstractExtension
         }*/
 
         /** @var array $arrStyles */
-        $arrStyles = StringUtil::deserialize($data['styleManager'], true);
+        $arrStyles = StringUtil::deserialize($data['styleManager'] ?? null, true);
 
         return new Styles($arrStyles[StyleManager::VARS_KEY] ?? null);
     }


### PR DESCRIPTION
When a Twig content element template is rendered outside the normal content element pipeline, the $data array passed to styleManager() has no styleManager key, so createContext() triggers a PHP warning on PHP 8. This adds a null coalesce so a missing key falls back to an empty Styles object, which is what the deserialize call already returns for null. Fixes #134.